### PR TITLE
fix: update to beets v2.5.1

### DIFF
--- a/beetsplug/beatport4.py
+++ b/beetsplug/beatport4.py
@@ -32,7 +32,8 @@ import beets
 import beets.ui
 import requests
 from beets.autotag.hooks import AlbumInfo, TrackInfo
-from beets.metadata_plugins import MetadataSourcePlugin, _get_distance
+from beets.autotag.match import distance
+from beets.metadata_plugins import MetadataSourcePlugin
 from beets.plugins import BeetsPlugin
 import confuse
 
@@ -619,7 +620,7 @@ class Beatport4Plugin(BeetsPlugin):
         """Returns the Beatport source weight and the maximum source weight
         for albums.
         """
-        return _get_distance(
+        return distance(
             data_source=self.data_source,
             info=album_info,
             config=self.config
@@ -629,7 +630,7 @@ class Beatport4Plugin(BeetsPlugin):
         """Returns the Beatport source weight and the maximum source weight
         for individual tracks.
         """
-        return _get_distance(
+        return distance(
             data_source=self.data_source,
             info=track_info,
             config=self.config


### PR DESCRIPTION
I'm itching to get my hands on some changes recently merged to beets trunk and figured I could use that motivation to get this over the line. Thanks for fixing the plugin to begin with and getting this update started.

- `MusicalKey` moved from `beets.library` to `beets.dbcore.types` ([commit](https://github.com/Samik081/beets-beatport4/pull/18/commits/f7b83b785ebd8f0fff0d3809096dde00cd162092))
- `MetadataSourcePlugin` moved from `beets.plugins` to `beets.metadata_plugins` ([commit](https://github.com/Samik081/beets-beatport4/pull/18/commits/f7b83b785ebd8f0fff0d3809096dde00cd162092))
- account for `art` module export changes ([commit](https://github.com/Samik081/beets-beatport4/commit/a205b163fd742dd14a335e52e0d1a6e1c6890668))
- `metadata_plugins._get_distance` is now `autotag.match.distance` ([commit](https://github.com/Samik081/beets-beatport4/commit/1ddec0dd655cd8b55d4a75fe5924bf65f07b3f92))