### PR TITLE
feat: adopt MetadataSourcePlugin interface released in v2.4.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ beets_beatport4.egg-info
 dist
 .idea/
 build/
+.mypy_cache

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,12 @@ dependencies = [
     "confuse",
 ]
 
+[project.optional-dependencies]
+dev = [
+    "mypy",
+    "types-requests",
+]
+
 [project.urls]
 "Homepage" = "https://github.com/Samik081/beets-beatport4"
 "Download" = "https://github.com/Samik081/beets-beatport4/releases/download/v0.4.0/beets-beatport4-0.4.0.tar.gz"


### PR DESCRIPTION
- Refactor into the [`MetadataSourcePlugin` interface](https://beets.readthedocs.io/en/v2.4.0/api/generated/beets.metadata_plugins.MetadataSourcePlugin.html) released with 2.4.0 (missed this on the first pass)
- Add `mypy` and `types-requests` to a new `dev` optional-dependencies group
- gitignore transient `.mypy_cache` content

