### PR TITLE
fix: Adapt to beets v2.7.0 genres list field and fix CI masking

### DIFF
--- a/.github/workflows/test-master.yml
+++ b/.github/workflows/test-master.yml
@@ -30,7 +30,6 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
-    continue-on-error: true
     strategy:
       matrix:
         python-version: ['3.10', '3.11', '3.12', '3.13']

--- a/beetsplug/beatport4/plugin.py
+++ b/beetsplug/beatport4/plugin.py
@@ -341,7 +341,6 @@ class Beatport4Plugin(MetadataSourcePlugin):
             media=MEDIA_TYPE,
             data_source=self.data_source,
             data_url=release.url,
-            genre=None,
         )
 
     def _get_track_info(self, track: BeatportTrack) -> TrackInfo:
@@ -409,7 +408,7 @@ class Beatport4Plugin(MetadataSourcePlugin):
             data_url=track.url,
             bpm=track.bpm,
             initial_key=track.initial_key,
-            genre=track.genre,
+            genres=[track.genre] if track.genre else None,
             **extra_fields,
         )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     'Programming Language :: Python :: 3.13',
 ]
 dependencies = [
-    "beets>=2.5.1",
+    "beets>=2.7.0",
     "requests",
     "confuse",
 ]

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -107,7 +107,7 @@ class TestGetTrackInfo:
         assert info.data_source == "Beatport"
         assert info.bpm == 128
         assert info.initial_key == "D#maj"
-        assert info.genre == "Tech House"
+        assert info.genres == ["Tech House"]
         assert info.data_url is not None
 
     def test_multiple_artists_joined(self, plugin):


### PR DESCRIPTION
## Summary

- **Adapt to beets v2.7.0 `genres` field**: Beets v2.7.0 replaced the `genre` (string) field with `genres` (list) on `TrackInfo`/`AlbumInfo`. Passing `genre=` now emits a `DeprecationWarning` and reading `info.genre` returns `None` even when data is present. This PR switches the plugin to use the new `genres` list API at the beets interface boundary.
- **Fix CI masking failures**: The `test-master.yml` workflow had `continue-on-error: true` at the job level, which silently masked all test failures against beets master, making the workflow always appear green.

## Changes

| File | Change |
|------|--------|
| `pyproject.toml` | Bump minimum beets to `>=2.7.0` |
| `beetsplug/beatport4/plugin.py` | `_get_track_info`: use `genres=[track.genre]` instead of `genre=track.genre` |
| `beetsplug/beatport4/plugin.py` | `_get_album_info`: remove redundant `genre=None` (None is the default) |
| `tests/test_plugin.py` | Update assertion: `info.genres == ["Tech House"]` |
| `.github/workflows/test-master.yml` | Remove `continue-on-error: true` |

> **Note:** No changes to `models.py` — `BeatportTrack.genre` is our internal dataclass field representing a single genre string from the Beatport API. The conversion to a list happens at the beets interface boundary in `plugin.py`.