### PR TITLE
fix(config): redact username and password

### DIFF
--- a/beetsplug/beatport4/plugin.py
+++ b/beetsplug/beatport4/plugin.py
@@ -67,6 +67,8 @@ class Beatport4Plugin(MetadataSourcePlugin):
                 },
             }
         )
+        self.config["username"].redact = True
+        self.config["password"].redact = True
         self.client: Beatport4Client | None = None
         self.register_listener("import_begin", self.setup)
         self.register_listener("import_task_files", self.import_task_files)

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -54,3 +54,7 @@ class TestPluginInterface:
 
     def test_default_config_penalty(self, plugin):
         assert plugin.config["data_source_mismatch_penalty"].get() == 0.5
+
+    def test_credentials_config_is_redacted(self, plugin):
+        assert plugin.config["username"].redact is True
+        assert plugin.config["password"].redact is True


### PR DESCRIPTION
Fixes #31 by marking the fields as redacted during `__init__`.