### PR TITLE
build: match upstream python version constraint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 ]
 description = "Plugin for beets (http://beets.io) to replace stock beatport plugin which is not yet compatible with Beatport API v4."
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.10,<3.15"
 license = "MIT"
 classifiers = [
     'Topic :: Multimedia :: Sound/Audio',


### PR DESCRIPTION
Fixes #33 by matching `beets`'s upstream Python requirement.

Before:

```shell
$ poetry install
Creating virtualenv beets-beatport4-wI-uYitv-py3.13 in /home/tturner/.cache/pypoetry/virtualenvs
Updating dependencies
Resolving dependencies... (2.0s)
Resolving dependencies... (2.1s)
The current project's supported Python range (>=3.15) is not compatible with some of the required packages Python requirement:
  - beets requires Python <3.15,>=3.10, so it will not be installable for Python >=3.15
  - beets requires Python <4,>=3.10, so it will not be installable for Python >=4
  - beets requires Python <4,>=3.10, so it will not be installable for Python >=4
  - beets requires Python <4,>=3.10, so it will not be installable for Python >=4
  - beets requires Python <3.15,>=3.10, so it will not be installable for Python >=3.15
  - beets requires Python <3.15,>=3.10, so it will not be installable for Python >=3.15

Because no versions of beets match >2.7.0,<2.7.1 || >2.7.1,<2.8.0 || >2.8.0,<2.9.0 || >2.9.0,<2.10.0 || >2.10.0,<2.11.0 || >2.11.0
 and beets (2.7.0) requires Python <4,>=3.10, beets is forbidden.
And because beets (2.7.1) requires Python <4,>=3.10
 and beets (2.8.0) requires Python <4,>=3.10, beets is forbidden.
And because beets (2.9.0) requires Python <3.15,>=3.10
 and beets (2.10.0) requires Python <3.15,>=3.10, beets is forbidden.
So, because beets (2.11.0) requires Python <3.15,>=3.10
 and beets-beatport4 depends on beets (>=2.7.0), version solving failed.

  * Check your dependencies Python requirement: The Python requirement can be specified via the `python` or `markers` properties

    For beets, a possible solution would be to set the `python` property to "<empty>"
For beets, a possible solution would be to set the `python` property to ">=3.15,<4"
For beets, a possible solution would be to set the `python` property to ">=3.15,<4"
For beets, a possible solution would be to set the `python` property to ">=3.15,<4"
For beets, a possible solution would be to set the `python` property to "<empty>"
For beets, a possible solution would be to set the `python` property to "<empty>"

    https://python-poetry.org/docs/dependency-specification/#python-restricted-dependencies,
    https://python-poetry.org/docs/dependency-specification/#using-environment-markers
```

After:

```shell
$ poetry install --no-root
Creating virtualenv beets-beatport4-wI-uYitv-py3.13 in /home/tturner/.cache/pypoetry/virtualenvs
Installing dependencies from lock file

Package operations: 23 installs, 0 updates, 0 removals

  - Installing beets (2.11.0): Pending...
  - Installing beets (2.11.0): Installing...
  - Installing beets (2.11.0)
  - Installing certifi (2026.5.20)
  - Installing charset-normalizer (3.4.7)
  - Installing confuse (2.2.0)
  - Installing idna (3.18)
  - Installing lap (0.5.13)
  - Installing jellyfish (1.2.1)
  - Installing filetype (1.2.0)
  - Installing mediafile (0.17.0)
  - Installing mutagen (1.47.0)
  - Installing llvmlite (0.47.0)
  - Installing numba (0.65.1)
  - Installing numpy (2.4.6)
  - Installing packaging (26.2)
  - Installing platformdirs (4.10.0)
  - Installing pyrate-limiter (4.2.0)
  - Installing requests (2.34.2)
  - Installing pyyaml (6.0.3)
  - Installing requests-ratelimiter (0.10.0)
  - Installing scipy (1.17.1)
  - Installing typing-extensions (4.15.0)
  - Installing unidecode (1.4.0)
  - Installing urllib3 (2.7.0)
```