### PR TITLE
ci: add Poetry build check against beets release and master

### DIFF
--- a/.github/workflows/test-poetry.yml
+++ b/.github/workflows/test-poetry.yml
@@ -1,0 +1,43 @@
+name: Test (Poetry build)
+
+# Poetry reads `requires-python` as an exact compatibility bound, so if this
+# plugin's range ever exceeds beets' own `requires-python`, dependency
+# resolution fails (see issue #33). This workflow runs Poetry's resolver
+# against both the latest beets release and beets master so the constraint
+# desync is caught early — on PRs and via the daily scheduled run.
+
+on:
+  pull_request:
+  schedule:
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  poetry:
+    name: Poetry resolve (beets ${{ matrix.beets-source }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        beets-source: [release, master]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Install Poetry
+        run: pipx install poetry
+
+      - name: Resolve dependencies (latest beets release)
+        if: matrix.beets-source == 'release'
+        run: poetry lock
+
+      - name: Resolve dependencies (beets master)
+        if: matrix.beets-source == 'master'
+        run: poetry add --lock "beets @ git+https://github.com/beetbox/beets.git@master"

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 [![Test (latest beets release)](https://github.com/Samik081/beets-beatport4/actions/workflows/test-release.yml/badge.svg)](https://github.com/Samik081/beets-beatport4/actions/workflows/test-release.yml)
 [![Test (beets master)](https://github.com/Samik081/beets-beatport4/actions/workflows/test-master.yml/badge.svg)](https://github.com/Samik081/beets-beatport4/actions/workflows/test-master.yml)
+[![Test (Poetry build)](https://github.com/Samik081/beets-beatport4/actions/workflows/test-poetry.yml/badge.svg)](https://github.com/Samik081/beets-beatport4/actions/workflows/test-poetry.yml)
 
 A drop-in replacement for the stock beets beatport plugin, updated for Beatport API v4.
 


### PR DESCRIPTION
## Summary

Follow-up to #33 (and #34, which fixed the constraint itself).

Poetry reads \`requires-python\` as an exact compatibility bound, so when this plugin's range exceeds beets' own \`requires-python\`, dependency resolution fails — that's the breakage reported in #33. `pip` doesn't catch this, so it went unnoticed.

This adds a **`Test (Poetry build)`** workflow that runs Poetry's resolver against:
- **latest beets release** (`poetry lock`, from PyPI)
- **beets master** (`poetry add --lock` with a git source) — for an early warning before a beets release even ships

It runs on PRs, a daily schedule (`0 6 * * *`, matching the existing workflows), and manual dispatch. A matching CI badge is added to the README.

## Why `poetry lock` and not `poetry install`

The desync bites at the dependency-resolution step, so `lock`/`--lock` is the precise probe and avoids unrelated root-package build noise.

## Validation (Poetry local)

| Scenario | Result |
| --- | --- |
| Release leg (`poetry lock`, PyPI) | exit 0 — resolves beets 2.11.0 |
| Master leg (`poetry add --lock`, git) | resolves against master |
| Reproduced #33 desync (`requires-python = ">=3.10"`) | **exit 1** — CI fails as intended |
| Correct constraint (`>=3.10,<3.15`) | exit 0 |