### PR TITLE
docs: drop obsolete credential-removal note from bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -66,7 +66,6 @@ body:
         ```
         beet config
         ```
-        **Remove your username/password before pasting!**
       render: yaml
       placeholder: |
         beatport4:


### PR DESCRIPTION
## Summary

Follow-up to #31 (fixed in #32).

Since #32 sets `config["username"].redact` / `config["password"].redact = True`, `beet config` now masks those values as `REDACTED` automatically. The **"Remove your username/password before pasting!"** warning in the bug report template's *Relevant configuration* section is therefore obsolete, so this removes it.

The traceback section already tells users that sensitive data is auto-redacted, so the template stays consistent.