### PR TITLE
fix(art): take track ID from match info instead of item mb_trackid

### DIFF
--- a/beetsplug/beatport4/plugin.py
+++ b/beetsplug/beatport4/plugin.py
@@ -174,7 +174,19 @@ class Beatport4Plugin(MetadataSourcePlugin):
 
             # All tracks on a Beatport release share the same cover
             # art, so fetch the image once using the first track.
-            first_id = items[0].get("mb_trackid")
+            # Take the track ID from the match info rather than the
+            # imported items: other plugins (e.g. zero) may blank
+            # mb_trackid on the items before this handler runs (#38).
+            info = task.match.info
+            if isinstance(info, AlbumInfo):
+                first_id = next(
+                    (t.track_id for t in info.tracks if t.track_id), None
+                )
+            else:
+                first_id = info.track_id
+            if not first_id:
+                self._log.debug("No Beatport track ID in match; skipping art")
+                return
             image_data = self.client.get_image(
                 first_id,
                 self.config["art_width"].get(),

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -498,13 +498,16 @@ class TestPluginSetup:
 def _make_mock_task(data_source="Beatport", track_ids=None):
     """Create a mock import task with the given data source."""
     task = MagicMock()
-    task.match.info.data_source = data_source
-    items = []
-    for tid in track_ids or ["123"]:
-        item = MagicMock()
-        item.get.return_value = tid
-        items.append(item)
-    task.imported_items.return_value = items
+    track_ids = track_ids or ["123"]
+    task.match.info = AlbumInfo(
+        album="Album",
+        album_id="1000",
+        artist="Artist",
+        artist_id="2000",
+        tracks=[TrackInfo(track_id=tid) for tid in track_ids],
+        data_source=data_source,
+    )
+    task.imported_items.return_value = [MagicMock() for _ in track_ids]
     return task
 
 
@@ -563,6 +566,54 @@ class TestImportTaskFiles:
             plugin_with_client.import_task_files(task)
             mock_client.get_image.assert_called_once()
             mock_art.embed_item.assert_called_once()
+
+    def test_uses_match_track_id_not_item_mb_trackid(
+        self, plugin_with_client, mock_client
+    ):
+        """Regression (#38): plugins like zero can blank mb_trackid on the
+        imported items before this handler runs, so the track ID must come
+        from the match info, not the items."""
+        plugin_with_client.config["art"].set(True)
+        plugin_with_client.config["art_overwrite"].set(True)
+        task = _make_mock_task(track_ids=["123"])
+        # Simulate the zero plugin having cleared mb_trackid
+        for item in task.imported_items.return_value:
+            item.get.return_value = ""
+        mock_client.get_image.return_value = b"\x89PNG fake"
+
+        with patch("beetsplug.beatport4.plugin.art") as mock_art:
+            plugin_with_client.import_task_files(task)
+            mock_client.get_image.assert_called_once()
+            assert mock_client.get_image.call_args[0][0] == "123"
+            mock_art.embed_item.assert_called_once()
+
+    def test_singleton_uses_match_track_id(
+        self, plugin_with_client, mock_client
+    ):
+        """Singleton imports carry a TrackInfo match instead of AlbumInfo."""
+        plugin_with_client.config["art"].set(True)
+        plugin_with_client.config["art_overwrite"].set(True)
+        task = MagicMock()
+        task.match.info = TrackInfo(track_id="456", data_source="Beatport")
+        task.imported_items.return_value = [MagicMock()]
+        mock_client.get_image.return_value = b"\x89PNG fake"
+
+        with patch("beetsplug.beatport4.plugin.art") as mock_art:
+            plugin_with_client.import_task_files(task)
+            mock_client.get_image.assert_called_once()
+            assert mock_client.get_image.call_args[0][0] == "456"
+            mock_art.embed_item.assert_called_once()
+
+    def test_skips_when_match_has_no_track_ids(
+        self, plugin_with_client, mock_client
+    ):
+        plugin_with_client.config["art"].set(True)
+        task = _make_mock_task(track_ids=[None])
+
+        with patch("beetsplug.beatport4.plugin.art") as mock_art:
+            plugin_with_client.import_task_files(task)
+            mock_client.get_image.assert_not_called()
+            mock_art.embed_item.assert_not_called()
 
     def test_returns_early_on_none_image_data(
         self, plugin_with_client, mock_client


### PR DESCRIPTION
## Summary

Fixes #38 — album art was not embedded and the import log showed:

```
beatport4: Failed to fetch track : Error 404 for '/v4/catalog/tracks//'
beatport4: No image data for track ; skipping
```

## Root cause

The `import_task_files` art hook read the Beatport track ID from `items[0].get("mb_trackid")`. Other plugins can blank that field on the shared in-memory `Item` objects before the hook runs — notably `zero` configured with `mb_trackid` in its fields and `update_database: true`, whose `write` listener sets `item[field] = None` during the import write phase. The hook then requested `/v4/catalog/tracks//` (empty ID), got a 404, and skipped art embedding. Reproduced exactly with `zero` + `scrub` enabled on both fresh imports and `-L` re-imports.

## Fix

Take the track ID from `task.match.info` — data the plugin itself produced — instead of the mutable library item:

- `AlbumInfo` matches: first track with a `track_id` (all tracks on a release share the same cover art)
- singleton `TrackInfo` matches: `info.track_id`
- no ID in the match: skip with a debug log instead of firing a bogus request

## Testing

- 3 new regression tests (blanked `mb_trackid`, singleton path, match without track IDs); full suite passes 140/140
- Verified end-to-end against the live Beatport API in an isolated `BEETSDIR` with `zero` (`mb_trackid` zeroed, `update_database: true`) + `scrub` enabled: re-import of the reporter's release (4194963) fetches and embeds art in all 4 files; singleton import path verified as well