### PR TITLE
feat: Add genres config option to write main genre, sub-genre, or both

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ For more info, see [this issue](https://github.com/beetbox/beets/issues/3862). A
 - [Album Art](#fetching-and-embedding-album-art)
   - [Image size](#image-size)
 - [Singleton Album Metadata](#singleton-album-metadata)
+- [Genres](#genres)
 - [Configuration Reference](#configuration-reference)
 - [Debug Logging & Sensitive Data](#debug-logging--sensitive-data)
 
@@ -146,6 +147,26 @@ beatport4:
 
 ---
 
+## Genres
+
+Beatport tracks always carry a main genre (e.g. `Trance (Main Floor)`) and, for some genres, a more specific sub-genre (e.g. `Hard Trance`). The `genres` option controls which of them the plugin passes to beets' multi-value `genres` field:
+
+```yaml
+beatport4:
+    genres: sub   # one of: sub (default), main, both
+```
+
+| Value | Result for a track with genre `Trance (Main Floor)` and sub-genre `Hard Trance` |
+|-------|-----------------------------------------------------------------------------|
+| `sub` *(default)* | `Hard Trance` — the sub-genre, falling back to the main genre when the track has no sub-genre |
+| `main` | `Trance (Main Floor)` — always the main genre |
+| `both` | `Trance (Main Floor)`, `Hard Trance` — both, main genre first |
+
+> [!NOTE]
+> Not every Beatport track has a sub-genre — for those, all three settings produce just the main genre.
+
+---
+
 ## Configuration Reference
 
 | Option | Type | Default | Description |
@@ -154,6 +175,7 @@ beatport4:
 | `art_overwrite` | bool | `no` | Overwrite existing art if already present |
 | `art_width` | int | *(none)* | Target image width in pixels (0 or omit to disable resizing) |
 | `art_height` | int | *(none)* | Target image height in pixels (0 or omit to disable resizing) |
+| `genres` | `sub` \| `main` \| `both` | `sub` | Which Beatport genre fields go into beets' `genres`: sub-genre (falling back to genre), main genre, or both |
 | `singletons_with_album_metadata.enabled` | bool | `no` | Fetch release data for singleton imports |
 | `singletons_with_album_metadata.year` | bool | `yes` | Populate release date fields |
 | `singletons_with_album_metadata.album` | bool | `yes` | Populate album name |
@@ -173,6 +195,7 @@ beatport4:
     art_overwrite: no
     art_width: 0
     art_height: 0
+    genres: sub
     singletons_with_album_metadata:
         enabled: no
         year: yes

--- a/beetsplug/beatport4/models.py
+++ b/beetsplug/beatport4/models.py
@@ -151,6 +151,7 @@ class BeatportTrack:
     url: str | None = None
     bpm: int | None = None
     genre: str | None = None
+    sub_genre: str | None = None
     image_url: str | None = None
     image_dynamic_url: str | None = None
     mix_name: str | None = None
@@ -185,10 +186,11 @@ class BeatportTrack:
             bpm = int(data["bpm"])
 
         genre = None
-        if data.get("sub_genre"):
-            genre = str(data["sub_genre"]["name"])
-        elif data.get("genre"):
+        if data.get("genre"):
             genre = str(data["genre"]["name"])
+        sub_genre = None
+        if data.get("sub_genre"):
+            sub_genre = str(data["sub_genre"]["name"])
 
         mix_name = data.get("mix_name")
         number = data.get("number")
@@ -220,6 +222,7 @@ class BeatportTrack:
             url=url,
             bpm=bpm,
             genre=genre,
+            sub_genre=sub_genre,
             image_url=image_url,
             image_dynamic_url=image_dynamic_url,
             mix_name=mix_name,

--- a/beetsplug/beatport4/plugin.py
+++ b/beetsplug/beatport4/plugin.py
@@ -56,6 +56,7 @@ class Beatport4Plugin(MetadataSourcePlugin):
                 "art_overwrite": False,
                 "art_width": None,
                 "art_height": None,
+                "genres": "sub",
                 "singletons_with_album_metadata": {
                     "enabled": False,
                     "year": True,
@@ -422,9 +423,22 @@ class Beatport4Plugin(MetadataSourcePlugin):
             data_url=track.url,
             bpm=track.bpm,
             initial_key=track.initial_key,
-            genres=[track.genre] if track.genre else None,
+            genres=self._get_genres(track),
             **extra_fields,
         )
+
+    def _get_genres(self, track: BeatportTrack) -> list[str] | None:
+        """Build the TrackInfo genres list from the track's Beatport genre
+        and sub-genre according to the ``genres`` config option.
+        """
+        mode = self.config["genres"].as_choice(["sub", "main", "both"])
+        if mode == "sub":
+            genres = [track.sub_genre or track.genre]
+        elif mode == "main":
+            genres = [track.genre]
+        else:
+            genres = [track.genre, track.sub_genre]
+        return [g for g in genres if g] or None
 
     def _get_artist(self, artists: object) -> tuple[str, str | None]:
         """Returns an artist string (all artists) and an artist_id (the main

--- a/tests/test_data_classes.py
+++ b/tests/test_data_classes.py
@@ -127,14 +127,23 @@ class TestBeatportTrack:
         assert track.url is not None
         assert track.length.total_seconds() == 360.0
 
-    def test_sub_genre_precedence(self, sample_track_data):
+    def test_genre_and_sub_genre_parsed(self, sample_track_data):
         track = BeatportTrack.from_api_response(sample_track_data)
-        assert track.genre == "Tech House"
+        assert track.genre == "House"
+        assert track.sub_genre == "Tech House"
 
-    def test_genre_fallback(self, sample_track_data):
+    def test_genre_only(self, sample_track_data):
         del sample_track_data["sub_genre"]
         track = BeatportTrack.from_api_response(sample_track_data)
         assert track.genre == "House"
+        assert track.sub_genre is None
+
+    def test_no_genre_data(self, sample_track_data):
+        del sample_track_data["sub_genre"]
+        del sample_track_data["genre"]
+        track = BeatportTrack.from_api_response(sample_track_data)
+        assert track.genre is None
+        assert track.sub_genre is None
 
     def test_length_fallback_to_string(self, sample_track_data):
         sample_track_data["length_ms"] = 0

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -4,6 +4,8 @@ import json
 from datetime import datetime, timedelta
 from unittest.mock import MagicMock, patch
 
+import confuse
+import pytest
 from beets.autotag.hooks import AlbumInfo, TrackInfo
 
 from beetsplug.beatport4 import (
@@ -35,7 +37,8 @@ def _make_bp_track(
     number=1,
     bpm=128,
     initial_key="D#maj",
-    genre="Tech House",
+    genre="House",
+    sub_genre="Tech House",
     url="https://beatport.com/track/test-track/300",
 ):
     return BeatportTrack(
@@ -48,6 +51,7 @@ def _make_bp_track(
         bpm=bpm,
         initial_key=initial_key,
         genre=genre,
+        sub_genre=sub_genre,
         url=url,
     )
 
@@ -119,6 +123,47 @@ class TestGetTrackInfo:
         info = plugin._get_track_info(track)
         assert "Alice" in info.artist
         assert "Bob" in info.artist
+
+
+class TestGetTrackInfoGenres:
+    def test_default_sub_mode_prefers_sub_genre(self, plugin):
+        track = _make_bp_track(genre="House", sub_genre="Tech House")
+        info = plugin._get_track_info(track)
+        assert info.genres == ["Tech House"]
+
+    def test_sub_mode_falls_back_to_main_genre(self, plugin):
+        track = _make_bp_track(genre="House", sub_genre=None)
+        info = plugin._get_track_info(track)
+        assert info.genres == ["House"]
+
+    def test_main_mode_uses_main_genre_only(self, plugin):
+        plugin.config["genres"] = "main"
+        track = _make_bp_track(genre="House", sub_genre="Tech House")
+        info = plugin._get_track_info(track)
+        assert info.genres == ["House"]
+
+    def test_both_mode_main_genre_first(self, plugin):
+        plugin.config["genres"] = "both"
+        track = _make_bp_track(genre="House", sub_genre="Tech House")
+        info = plugin._get_track_info(track)
+        assert info.genres == ["House", "Tech House"]
+
+    def test_both_mode_without_sub_genre(self, plugin):
+        plugin.config["genres"] = "both"
+        track = _make_bp_track(genre="House", sub_genre=None)
+        info = plugin._get_track_info(track)
+        assert info.genres == ["House"]
+
+    def test_no_genre_data_yields_none(self, plugin):
+        track = _make_bp_track(genre=None, sub_genre=None)
+        info = plugin._get_track_info(track)
+        assert info.genres is None
+
+    def test_invalid_mode_raises_config_error(self, plugin):
+        plugin.config["genres"] = "everything"
+        track = _make_bp_track()
+        with pytest.raises(confuse.ConfigValueError):
+            plugin._get_track_info(track)
 
 
 # ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
Adds a `genres` config option (`sub` | `main` | `both`, default `sub`) controlling which Beatport genre fields are written to beets' multi-value `genres` field.

- `sub` (default): sub-genre, falling back to the main genre — exactly the current behavior
- `main`: always the main genre
- `both`: main genre first, then sub-genre

`BeatportTrack` now keeps `genre` and `sub_genre` as separate fields; the selection happens in the plugin (`_get_genres()`), validated via confuse `as_choice`, so an invalid value fails loudly instead of silently mistagging.

Verified end-to-end against the live Beatport API with track 16772903 from the issue (Trance (Main Floor) / Hard Trance): `track_for_id` returns both genres in order, a real singleton `beet import --search-id` writes `genres: Trance (Main Floor); Hard Trance` to the library, and the file itself carries both values as multi-value genre tags. The default mode was also live-verified to keep today's behavior.

Fixes #37